### PR TITLE
fix bug for multiple filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var es = require('event-stream'),
-  gutil = require('gulp-util');
+    gutil = require('gulp-util');
 
 module.exports = function (opt) {
   function gulpDeleteLines(file) {
@@ -7,20 +7,18 @@ module.exports = function (opt) {
     if (file.isStream()) return this.emit('error', new Error("gulp-delete-lines: Streaming not supported"));
     var str = file.contents.toString('utf8');
     var line, _i, _j, _len, lines;
-    var newLines = [];
 
     lines = str.split(/\r\n|\r|\n/g);
 
     for (_i = 0; _i < lines.length; _i++) {
-
       for (_j = 0; _j < opt.filters.length; _j++) {
-        if (! lines[_i].match(opt.filters[_j])) {
-			newLines.push(lines[_i]);
+        if(lines[_i].match(opt.filters[_j])){
+          lines.splice(_i, 1);
+          _i--;
         }
       }
     }
-
-    str = newLines.join('\n');
+    str = lines.join('\n');
 
     file.contents = new Buffer(str);
     this.emit('data', file);


### PR DESCRIPTION
this interface allows multiple regexp for filters.
but in that case, each line will push to newLines multi times.

support filters correct, and only add each line by one.
