### PR TITLE
replace file.content only when needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,10 @@ module.exports = function (opt) {
       }
     }
 
-    str = newLines.join('\n');
-
-    file.contents = new Buffer(str);
+    if (lines.length != newLines.length) {
+      str = newLines.join('\n');
+      file.contents = new Buffer(str);
+    }
     this.emit('data', file);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-delete-lines",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A gulp plugin that will delete all lines that matches one of the given regex filters.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Hi, I'm using gulp-delete-lines during copying files to dist folder. Some of the files are image assets and they are being broken during the file processing in gulp-delete-lines. I think that file.content could be replaced only when there was any line removed.
