### PR TITLE
Removed dependancy on gulp-util from package.json + version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "gulp-rm-lines",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A gulp plugin that will delete all lines that match one of the given regex filters.",
   "main": "index.js",
   "dependencies": {
-    "gulp-util": ">=2.2.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {},


### PR DESCRIPTION
Related PR #10

Please push this to npm as well, we get critical security alert on every build.

```shell
lodash.template  *
Severity: high
Command Injection in lodash - https://github.com/advisories/GHSA-35jh-r3h4-6jhm
No fix available
node_modules/lodash.template
  gulp-util  >=1.1.0
  Depends on vulnerable versions of lodash.template
  node_modules/gulp-util
    gulp-rm-lines  <=0.0.9
    Depends on vulnerable versions of gulp-util
    node_modules/gulp-rm-lines
```